### PR TITLE
Fixed - automatic port scanning

### DIFF
--- a/utils/network/port_finder_adb.py
+++ b/utils/network/port_finder_adb.py
@@ -1,0 +1,45 @@
+import subprocess
+import re
+
+from pathlib import Path
+
+relative_path = Path(__file__).parent.parents[1]
+ADB_PATH = f"{str(relative_path)}\\adb-bin\\adb.exe"
+
+def find_port_adb(target_ip):
+    try:
+        result = subprocess.run(
+            [ADB_PATH, "mdns", "services"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+    except FileNotFoundError:
+        raise RuntimeError("adb.exe not found. Check ADB_PATH.")
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"adb command failed: {e}")
+
+    text = result.stdout
+    if not text:
+        return None
+
+    matches = re.findall(
+        r'((?:\d{1,3}\.){3}\d{1,3}):(\d{2,5})',
+        text
+    )
+
+    for ip, port in matches:
+        if ip == target_ip:
+            return int(port)
+
+    return None
+
+
+# example usage
+if __name__ == "__main__":
+    ip = "192.168.31.34"
+    try:
+        port = find_port_adb(ip)
+        print(port if port else "IP not found")
+    except RuntimeError as err:
+        print("Error:", err)

--- a/utils/network/port_scan.py
+++ b/utils/network/port_scan.py
@@ -4,6 +4,8 @@ from concurrent.futures import Future, ThreadPoolExecutor
 
 from utils.logger import LOGGER, LogType
 
+import utils.network.port_finder_adb as pfa
+
 DEFAULT_START_PORT = 32000
 DEFAULT_END_PORT = 47000
 DEFAULT_STEP = 512
@@ -42,4 +44,7 @@ def scan_port(ip: str) -> list[int]:
         except Exception as e:
             LOGGER.write(LogType.Error, "Port scanning error: " + str(e))
     executor.shutdown(cancel_futures=True)
+
+    target_ports += [pfa.find_port_adb(ip)]
+    
     return target_ports


### PR DESCRIPTION
Previously automatic port scanning did not always work.
This code will use `adb mdns services` to list possible connections and automatically extract port for the given IP. 
This along with the previous port scanning method will make sure that port scanning does not fail. 