### PR TITLE
Bump pynput to fix crash on Python 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 adbutils==1.2.15
 customtkinter==5.2.2
-pynput==1.7.6
+pynput==1.8.1
 notify_py==0.3.43
 pyperclip==1.9.0
 pystray==0.19.5


### PR DESCRIPTION
pynput 1.7.6 has a known incompatibility with Python 3.13's threading
internals — keyboard listener callbacks throw:

  TypeError: '_thread._ThreadHandle' object is not callable

Bumping to pynput>=1.8.1 resolves it. Tested on Windows 11, Python 3.13.