### PR TITLE
Add audio forwarding via existing scrcpy-server (raw PCM)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
             --add-data "./server/scrcpy-server;server/" `
             --add-data "./server/reporter.apk;server/" `
             --add-data "./build_venv/Lib/site-packages/customtkinter;customtkinter/" `
+            --collect-all sounddevice `
             --noconfirm main.py
         env:
           PYTHONUNBUFFERED: 1

--- a/main.py
+++ b/main.py
@@ -62,11 +62,21 @@ if __name__ == "__main__":
             sys.exit(1)
         append_adb_device(device_list[0])
 
-    res = deploy_scrcpy_server()
+    res = deploy_scrcpy_server(get_config().forward_audio)
     if isinstance(res, Exception):
         close_notification_resolver(res)
         sys.exit(1)
-    scrcpy_server_process, scrcpy_client_socket = res
+    scrcpy_server_process, scrcpy_client_socket, scrcpy_audio_socket = res
+
+    stop_audio_player: Callable | None = None
+    if scrcpy_audio_socket is not None:
+        try:
+            from server.audio_player import audio_player_factory
+            stop_audio_player = audio_player_factory(scrcpy_audio_socket)
+        except Exception as e:
+            # a missing output device should not prevent the input sharing
+            LOGGER.write(LogType.Error, "Audio playing unavailable: " + str(e))
+            scrcpy_audio_socket.close()
 
     stop_scrcpy_receiver = scrcpy_receiver.server_receiver_factory(scrcpy_client_socket)
     stop_reporter_receiver: Callable | None = None
@@ -87,6 +97,7 @@ if __name__ == "__main__":
     LOGGER.write(LogType.Info, "Terminated, closing...")
     stop_scrcpy_receiver()
     stop_reporter_receiver and stop_reporter_receiver() # type: ignore
+    stop_audio_player and stop_audio_player() # type: ignore
     scrcpy_server_process.terminate()
 
     close_notification_resolver(main_errno)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 adbutils==1.2.15
 customtkinter==5.2.2
-pynput==1.7.6
+pynput==1.8.1
 notify_py==0.3.43
 pyperclip==1.9.0
 pystray==0.19.5
 screeninfo==0.8.1
+sounddevice==0.5.5

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,25 +1,55 @@
 import socket
 import subprocess
+from adbutils import AdbDevice
 from server import scrcpy_receiver, reporter_receiver
 from utils.adb_controller import get_adb_device
 from utils.logger import LOGGER, LogType
 
-def deploy_scrcpy_server() -> tuple[subprocess.Popen, socket.socket] | Exception:
+# audio capture is only available since Android 11
+AUDIO_MINIMAL_SDK_VERSION = 30
+
+def is_audio_supported(device: AdbDevice) -> bool:
+    sdk_version = device.shell("getprop ro.build.version.sdk")
+    assert type(sdk_version) == str
+    if not sdk_version.strip().isdigit():
+        LOGGER.write(LogType.Error, "Failed to read device SDK version, audio disabled.")
+        return False
+    if int(sdk_version) < AUDIO_MINIMAL_SDK_VERSION:
+        LOGGER.write(LogType.Server, "Device is older than Android 11, audio disabled.")
+        return False
+    return True
+
+def deploy_scrcpy_server(enable_audio: bool=False) -> tuple[subprocess.Popen, socket.socket, socket.socket | None] | Exception:
     primary_device = get_adb_device()
     if isinstance(primary_device, Exception): return primary_device
 
     scrcpy_receiver.push_server(primary_device)
     primary_device.forward(f"tcp:{scrcpy_receiver.SERVER_PORT}", "localabstract:scrcpy")
 
-    server_process = scrcpy_receiver.server_process_factory()
+    # requesting audio from a device that can not capture it
+    # makes the server abort, which would break the input sharing too
+    enable_audio = enable_audio and is_audio_supported(primary_device)
+
+    server_process = scrcpy_receiver.server_process_factory(enable_audio)
     if isinstance(server_process, Exception):
         return server_process
 
-    client_socket = scrcpy_receiver.try_connect_server("localhost")
+    # with the video stream disabled, the audio socket is the first one
+    # to be connected, so it is the one receiving the dummy byte
+    audio_socket = None
+    if enable_audio:
+        audio_socket = scrcpy_receiver.try_connect_server("localhost")
+        if isinstance(audio_socket, Exception):
+            server_process.terminate()
+            return audio_socket
+
+    client_socket = scrcpy_receiver.try_connect_server("localhost", expect_dummy_byte=not enable_audio)
     if isinstance(client_socket, Exception):
+        audio_socket and audio_socket.close()
+        server_process.terminate()
         return client_socket
 
-    return server_process, client_socket
+    return server_process, client_socket, audio_socket
 
 def deploy_reporter_server() -> Exception | None:
     primary_device = get_adb_device()

--- a/server/audio_player.py
+++ b/server/audio_player.py
@@ -1,0 +1,61 @@
+import socket
+import threading
+
+import sounddevice as sd
+
+from utils import VoidCallable
+from utils.logger import LOGGER, LogType
+
+# scrcpy raw audio format (see AudioCapture.java): 48kHz, stereo, signed 16-bit LE PCM
+SAMPLE_RATE = 48000
+CHANNELS = 2
+BYTES_PER_SAMPLE = 2
+FRAME_BYTES = CHANNELS * BYTES_PER_SAMPLE
+RECV_BUFFER_SIZE = 4096
+
+def audio_player_factory(audio_socket: socket.socket) -> VoidCallable:
+    stream = sd.RawOutputStream(
+        samplerate=SAMPLE_RATE,
+        channels=CHANNELS,
+        dtype="int16",
+        blocksize=0,   # let PortAudio pick its optimal block size
+        latency="low",
+    )
+
+    def player_loop():
+        # a TCP read can end in the middle of a frame, while the output stream
+        # only accepts whole frames; the partial tail is kept for the next write
+        # to prevent the channels from being permanently swapped
+        residual = b""
+        try:
+            stream.start()
+            while True:
+                data = audio_socket.recv(RECV_BUFFER_SIZE)
+                if len(data) == 0:
+                    LOGGER.write(LogType.Server, "Scrcpy server closed audio connection.")
+                    break
+                data = residual + data
+                aligned_size = len(data) - len(data) % FRAME_BYTES
+                residual = data[aligned_size:]
+                if aligned_size > 0:
+                    stream.write(data[:aligned_size])
+        except (ConnectionAbortedError, ConnectionResetError, OSError) as e:
+            LOGGER.write(LogType.Error, "Audio connection error: " + str(e))
+        except Exception as e:
+            LOGGER.write(LogType.Error, "Audio playing error: " + str(e))
+        finally:
+            try:
+                stream.stop()
+                stream.close()
+            except Exception as e:
+                LOGGER.write(LogType.Error, "Audio stream closing error: " + str(e))
+        LOGGER.write(LogType.Server, "Audio player stopped.")
+
+    def stop_player():
+        nonlocal audio_socket, thread
+        audio_socket.close()
+        thread.join()
+
+    thread = threading.Thread(target=player_loop)
+    thread.start()
+    return stop_player

--- a/server/audio_player.py
+++ b/server/audio_player.py
@@ -1,61 +1,107 @@
 import socket
 import threading
+import time
 
 import sounddevice as sd
 
 from utils import VoidCallable
 from utils.logger import LOGGER, LogType
 
-# scrcpy raw audio format (see AudioCapture.java): 48kHz, stereo, signed 16-bit LE PCM
+# scrcpy raw audio format: 48kHz, stereo, signed 16-bit LE PCM
 SAMPLE_RATE = 48000
 CHANNELS = 2
 BYTES_PER_SAMPLE = 2
 FRAME_BYTES = CHANNELS * BYTES_PER_SAMPLE
-RECV_BUFFER_SIZE = 4096
+
+# Cap how much audio we allow to queue up. Keeping this small means a
+# stall (e.g. the device sleeping, then dumping a backlog on wake) gets
+# trimmed back to "live" instead of playing out as growing lag.
+MAX_BUFFER_MS = 150
+MAX_BUFFER_BYTES = int(SAMPLE_RATE * MAX_BUFFER_MS / 1000) * FRAME_BYTES
+
+CHUNK_READ_SIZE = 4096
+
+# If no audio arrives for this long, treat the next chunk as stale/post-sleep
+# backlog and flush the buffer instead of playing out accumulated lag.
+STALE_GAP_SECONDS = 0.5
+
 
 def audio_player_factory(audio_socket: socket.socket) -> VoidCallable:
+    buffer = bytearray()
+    buffer_lock = threading.Lock()
+    stop_event = threading.Event()
+
+    def callback(outdata, frames, time_info, status):
+        needed = frames * FRAME_BYTES
+        with buffer_lock:
+            available = len(buffer)
+            if available >= needed:
+                chunk = bytes(buffer[:needed])
+                del buffer[:needed]
+            else:
+                # underrun: play what we have, pad the rest with silence
+                chunk = bytes(buffer) + b"\x00" * (needed - available)
+                buffer.clear()
+        outdata[:] = chunk
+
     stream = sd.RawOutputStream(
         samplerate=SAMPLE_RATE,
         channels=CHANNELS,
         dtype="int16",
-        blocksize=0,   # let PortAudio pick its optimal block size
-        latency="low",
+        callback=callback,
     )
 
-    def player_loop():
-        # a TCP read can end in the middle of a frame, while the output stream
-        # only accepts whole frames; the partial tail is kept for the next write
-        # to prevent the channels from being permanently swapped
-        residual = b""
+    def reader_loop():
+        last_recv_time = time.monotonic()
         try:
             stream.start()
-            while True:
-                data = audio_socket.recv(RECV_BUFFER_SIZE)
-                if len(data) == 0:
-                    LOGGER.write(LogType.Server, "Scrcpy server closed audio connection.")
+            while not stop_event.is_set():
+                data = audio_socket.recv(CHUNK_READ_SIZE)
+                if not data:
+                    LOGGER.write(LogType.Server, "Audio socket closed by server.")
                     break
-                data = residual + data
-                aligned_size = len(data) - len(data) % FRAME_BYTES
-                residual = data[aligned_size:]
-                if aligned_size > 0:
-                    stream.write(data[:aligned_size])
+
+                now = time.monotonic()
+                gap = now - last_recv_time
+                last_recv_time = now
+
+                with buffer_lock:
+                    if gap > STALE_GAP_SECONDS:
+                        # Tablet was likely asleep — this data is stale/backlogged.
+                        # Drop whatever's queued and start fresh rather than
+                        # playing out a growing backlog.
+                        LOGGER.write(LogType.Server, f"Audio gap of {gap:.2f}s detected, flushing buffer.")
+                        buffer.clear()
+
+                    buffer.extend(data)
+                    # Normal jitter-smoothing cap, unrelated to the sleep case.
+                    # Trim only whole frames so channels never desync.
+                    excess = len(buffer) - MAX_BUFFER_BYTES
+                    if excess > 0:
+                        excess -= excess % FRAME_BYTES
+                        if excess > 0:
+                            del buffer[:excess]
         except (ConnectionAbortedError, ConnectionResetError, OSError) as e:
             LOGGER.write(LogType.Error, "Audio connection error: " + str(e))
         except Exception as e:
-            LOGGER.write(LogType.Error, "Audio playing error: " + str(e))
+            LOGGER.write(LogType.Error, "Audio player error: " + str(e))
         finally:
             try:
                 stream.stop()
                 stream.close()
-            except Exception as e:
-                LOGGER.write(LogType.Error, "Audio stream closing error: " + str(e))
-        LOGGER.write(LogType.Server, "Audio player stopped.")
+            except Exception:
+                pass
+            LOGGER.write(LogType.Server, "Audio player stopped.")
+
+    thread = threading.Thread(target=reader_loop, daemon=True)
+    thread.start()
 
     def stop_player():
-        nonlocal audio_socket, thread
-        audio_socket.close()
-        thread.join()
+        stop_event.set()
+        try:
+            audio_socket.close()
+        except Exception:
+            pass
+        thread.join(timeout=2)
 
-    thread = threading.Thread(target=player_loop)
-    thread.start()
     return stop_player

--- a/server/scrcpy_receiver.py
+++ b/server/scrcpy_receiver.py
@@ -24,10 +24,12 @@ def push_server(device: AdbDevice):
     server_binary_path = Path.joinpath(script_path, SERVER_EXECUTABLE_NAME)
     device.sync.push(str(server_binary_path), target_path)
 
-def server_process_factory() -> subprocess.Popen | Exception:
-    INSTALL_SCRCPY_SERVER_COMMAND = "CLASSPATH=/data/local/tmp/scrcpy-server-manual.jar \
+def server_process_factory(enable_audio: bool=False) -> subprocess.Popen | Exception:
+    # the raw codec makes the server send bare PCM, so no decoding is needed here
+    audio_options = "audio=true audio_codec=raw" if enable_audio else "audio=false"
+    INSTALL_SCRCPY_SERVER_COMMAND = f"CLASSPATH=/data/local/tmp/scrcpy-server-manual.jar \
 app_process / com.genymobile.scrcpy.Server 2.7 \
-tunnel_forward=true video=false audio=false control=true \
+tunnel_forward=true video=false {audio_options} control=true \
 cleanup=false raw_stream=true send_dummy_byte=true max_size=4096"
     primary_device = get_adb_device()
     if isinstance(primary_device, Exception): return primary_device
@@ -47,9 +49,13 @@ cleanup=false raw_stream=true send_dummy_byte=true max_size=4096"
     time.sleep(1)
     return process
 
-def try_connect_server(host: str, port: int=SERVER_PORT) -> socket.socket | Exception:
+def try_connect_server(host: str, port: int=SERVER_PORT, expect_dummy_byte: bool=True) -> socket.socket | Exception:
     client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     client_socket.connect((host, port))
+
+    # the server sends the dummy byte on the first connected socket only
+    if not expect_dummy_byte:
+        return client_socket
 
     client_socket.settimeout(3)
     try:

--- a/ui/settings.py
+++ b/ui/settings.py
@@ -182,6 +182,28 @@ def mount_elements(root: ctk.CTk):
         check_box.grid(row=0, column=1)
         info_label.grid(row=1, column=0, columnspan=2, padx=20)
 
+    def forward_audio_section():
+        nonlocal settings_scroll_frame, smaller_font, normal_font, larger_font, forward_audio_var
+        forward_audio_frame = ctk.CTkFrame(master=settings_scroll_frame)
+        forward_audio_label = ctk.CTkLabel(
+            master=forward_audio_frame,
+            font=larger_font,
+            text=i18n(["Audio Forwarding: ", "音频转发："]))
+        check_box = ctk.CTkCheckBox(
+            master=forward_audio_frame,
+            text="",
+            variable=forward_audio_var)
+        info_label = ctk.CTkLabel(
+            master=forward_audio_frame,
+            font=smaller_font,
+            justify="left",
+            text=i18n(["When enabled, the audio of the Android device is played on this computer.\nRequires Android 11 or above.",
+                       "启用后，安卓设备的音频将在本电脑上播放。需要安卓 11 及以上版本。"]))
+        forward_audio_frame.pack(fill="x", pady=(20, 0))
+        forward_audio_label.grid(row=0, column=0, padx=(20, 0), sticky="w")
+        check_box.grid(row=0, column=1)
+        info_label.grid(row=1, column=0, columnspan=2, padx=20)
+
     def mount_language_section():
         nonlocal settings_scroll_frame, smaller_font, normal_font, larger_font, language_var
         language_frame = ctk.CTkFrame(master=settings_scroll_frame)
@@ -216,6 +238,7 @@ def mount_elements(root: ctk.CTk):
         config.device_position = device_position_var.get()
         config.trigger_margin  = int(trigger_margin_var.get())
         config.keep_wakeup     = keep_wakeup_var.get()
+        config.forward_audio   = forward_audio_var.get()
         config.language        = language_var.get()
         root.destroy()
 
@@ -233,12 +256,14 @@ def mount_elements(root: ctk.CTk):
     device_position_var = ctk.StringVar (master=settings_scroll_frame, value=config.device_position)
     trigger_margin_var  = ctk.StringVar (master=settings_scroll_frame, value=str(config.trigger_margin))
     keep_wakeup_var     = ctk.BooleanVar(master=settings_scroll_frame, value=config.keep_wakeup)
+    forward_audio_var   = ctk.BooleanVar(master=settings_scroll_frame, value=config.forward_audio)
     language_var        = ctk.StringVar (master=settings_scroll_frame, value=i18n([ENGLISH_LANGUAGE, CHINESE_LANGUAGE]))
 
     mouse_theme_section()
     mount_speed_section()
     edge_toggling_section()
     keep_wakeup_section()
+    forward_audio_section()
     mount_language_section()
 
     # action buttons section

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -14,6 +14,7 @@ class ConfigFile:
     scan_port: bool = False
     sync_clipboard: bool = True
     share_keyboard_only: bool = False
+    forward_audio: bool = False
 
     # settings
     theme: str = "system"


### PR DESCRIPTION
Title: Add audio forwarding via existing scrcpy-server (raw PCM)

Description:

What this does

Forwards the Android device's audio output to the PC over the existing ADB connection, using the scrcpy-server jar InputShare already bundles and deploys. No new device-side code was needed — the audio capture is native to the scrcpy server; this PR just enables and consumes it.

Approach
Server launch: audio=false → audio=true audio_codec=raw. Combined with the existing raw_stream=true, this gives a headerless 48kHz stereo 16-bit PCM stream with no encoding/decoding overhead.
Connection order: with video disabled, the audio socket is accepted by the device before the control socket. The dummy byte (used for connection confirmation) only arrives on whichever socket connects first, so try_connect_server now takes an expect_dummy_byte flag to handle this correctly for both sockets.
Playback: a small dedicated thread (server/audio_player.py) reads PCM off the socket and plays it via sounddevice/PortAudio. Runs independently of the control/input path so a slow audio device can't block input.
Settings: audio forwarding is off by default and toggleable via a new checkbox in Settings, stored in config (forward_audio_section() alongside the existing edge-toggling/keep-awake sections), so existing input-only users are unaffected unless they opt in.
Packaging: added --collect-all sounddevice to the PyInstaller build workflow, since it wraps a native PortAudio DLL that isn't picked up automatically.
Testing

Tested on a Samsung Tab S9 Ultra (SM-X910), Android 16, wired USB connection, Windows 11 / Python 3.13. Audio is clear with near-imperceptible latency on video playback, and works correctly alongside both edge-toggling and hotkey-based input switching. Device-side audio is silenced while forwarding (default scrcpy capture behavior), happy to add --audio-dup as a follow-up if duplicating audio on-device is wanted too.
Also tested in the wireless mode and although it works there is a very minor but noticeable delay in audio.

Notes for reviewers
This PR includes the pynput bump from #61  since it's needed to run on Python 3.13 — if that one merges first, I'm happy to rebase this and drop the duplicate change.
Open to feedback on: whether raw PCM vs. a compressed codec is the right default, buffer/latency tuning, and whether an --audio-dup toggle belongs in this PR or a follow-up.

**Note for usage:** audio forwarding defaults to **off** — it's opt-in via the new checkbox in Settings, so existing input-only users see no behavior change unless they explicitly enable it.
**Update:** fixed an issue where audio latency would accumulate and never recover after the device screen slept/woke (common in real use). The player now detects the stale gap on wake and flushes its buffer instead of playing out the backlog.


Closes #14